### PR TITLE
Perform all lookups using a configurable LookupEnv function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This one has several attractive properties:
 
 ```go
 import (
+	"os"
 	"time"
 
 	"github.com/datawire/envconfig"
@@ -51,7 +52,7 @@ func ConfigFromEnv() (cfg Config, warn []error, fatal []error) {
 		// runtime error.
 		panic(err)
 	}
-	warn, fatal = parser.ParseFromEnv(&cfg)
+	warn, fatal = parser.ParseFromEnv(&cfg, os.LookupEnv)
 	return
 }
 ```

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -3,6 +3,7 @@ package envconfig_test
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -41,7 +42,7 @@ func TestAbsoluteURL(t *testing.T) {
 			config.U = nil
 			t.Setenv("CONFIG_URL", tc.Input)
 
-			warn, fatal := parser.ParseFromEnv(&config)
+			warn, fatal := parser.ParseFromEnv(&config, os.LookupEnv)
 
 			assert.Equal(t, len(warn), 0, "There should be no warnings")
 			if tc.ExpectError {
@@ -73,7 +74,7 @@ func TestRecursive(t *testing.T) {
 	t.Setenv("PARENT_THING", "foo")
 	t.Setenv("CHILD_THING1", "bar")
 	t.Setenv("CHILD_THING2", "baz")
-	warn, fatal := parser.ParseFromEnv(&config)
+	warn, fatal := parser.ParseFromEnv(&config, os.LookupEnv)
 	assert.Equal(t, len(warn), 0, "There should be no warnings")
 	assert.Equal(t, len(fatal), 0, "There should be no errors")
 	assert.Equal(t, config.ParentThing, "foo")
@@ -240,7 +241,7 @@ func TestSmokeTestAllParsers(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					warn, fatal := parser.ParseUsingLookup(testinfo.Object, func(key string) (string, bool) {
+					warn, fatal := parser.ParseFromEnv(testinfo.Object, func(key string) (string, bool) {
 						if key == "VALUE" {
 							return testinfo.EnvVar, true
 						}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -240,8 +240,12 @@ func TestSmokeTestAllParsers(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					t.Setenv("VALUE", testinfo.EnvVar)
-					warn, fatal := parser.ParseFromEnv(testinfo.Object)
+					warn, fatal := parser.ParseUsingLookup(testinfo.Object, func(key string) (string, bool) {
+						if key == "VALUE" {
+							return testinfo.EnvVar, true
+						}
+						return "", false
+					})
 					assert.Equalf(t, testinfo.Warnings, len(warn), "There should be %d warnings", testinfo.Warnings)
 					assert.Equalf(t, testinfo.Errors, len(fatal), "There should be %d errors", testinfo.Errors)
 					assert.Equal(t, testinfo.Expected, fmt.Sprintf("%v", testinfo.Object))


### PR DESCRIPTION
Adds the new type `type LookupEnv func(key string) (string, bool)` and a new `StructParser.ParseUsingLookup` method that takes a `LookupEnv`. argument. This enables tests to use this package without concern of concurrency issues with global environment variables.