### PR TITLE
Add comma-split-trim, a parser for the []string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ whitespace for readability.
 
    ```go
    struct {
-       NonConfigurableDir   string   `env:",const=true   ,parser=nonempty-string    ,default=/opt/some-dir  "`
+   	NonConfigurableDir   string   `env:",const=true   ,parser=nonempty-string    ,default=/opt/some-dir  "`
    }
    ```
 
@@ -125,8 +125,8 @@ whitespace for readability.
 
    ```go
    struct {
-       Timeout_LowPrecendence   time.Duration  `env:"TIMEOUT_S  ,parser=integer-seconds     ,default=5                         "`
-       Timeout_HighPrecendence  time.Duration  `env:"TIMEOUT    ,parser=time.ParseDuration  ,defaultFrom=TimeoutLowPrecedence  "`
-       Timeout                  time.Duration  `env:",const     ,parser=time.ParseDuration  ,defaultFrom=TimeoutHighPrecedence "`
+   	Timeout_LowPrecendence   time.Duration  `env:"TIMEOUT_S  ,parser=integer-seconds     ,default=5                         "`
+   	Timeout_HighPrecendence  time.Duration  `env:"TIMEOUT    ,parser=time.ParseDuration  ,defaultFrom=TimeoutLowPrecedence  "`
+   	Timeout                  time.Duration  `env:",const     ,parser=time.ParseDuration  ,defaultFrom=TimeoutHighPrecedence "`
    }
    ```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ whitespace for readability.
 
    ```go
    struct {
-   	NonConfigurableDir   string   `env:",const=true   ,parser=nonempty-string    ,default=/opt/some-dir  "`
+       NonConfigurableDir   string   `env:",const=true   ,parser=nonempty-string    ,default=/opt/some-dir  "`
    }
    ```
 
@@ -99,7 +99,10 @@ whitespace for readability.
    `default=` flag is not present, then this struct member is
    considered to be **required**, and `ParseFromEnv` will return an
    error if the env-var is unset or invalid.  The string passed to the
-   `default=` flag is interpretted according to the `parser=`.
+   `default=` flag is interpreted according to the `parser=`.
+
+   The value following `default=` can contain commas, so this item
+   must be the last one in the `env` tag.
 
  - `defaultFrom`=membername
 
@@ -122,8 +125,8 @@ whitespace for readability.
 
    ```go
    struct {
-   	Timeout_LowPrecendence   time.Duration  `env:"TIMEOUT_S  ,parser=integer-seconds     ,default=5                         "`
-   	Timeout_HighPrecendence  time.Duration  `env:"TIMEOUT    ,parser=time.ParseDuration  ,defaultFrom=TimeoutLowPrecedence  "`
-   	Timeout                  time.Duration  `env:",const     ,parser=time.ParseDuration  ,defaultFrom=TimeoutHighPrecedence "`
+       Timeout_LowPrecendence   time.Duration  `env:"TIMEOUT_S  ,parser=integer-seconds     ,default=5                         "`
+       Timeout_HighPrecendence  time.Duration  `env:"TIMEOUT    ,parser=time.ParseDuration  ,defaultFrom=TimeoutLowPrecedence  "`
+       Timeout                  time.Duration  `env:",const     ,parser=time.ParseDuration  ,defaultFrom=TimeoutHighPrecedence "`
    }
    ```

--- a/envconfig.go
+++ b/envconfig.go
@@ -28,7 +28,7 @@ type envTagOption struct {
 // ErrNotSet is the error that gets wrapped when a "required" env-var is not set.
 var ErrNotSet = errors.New("is not set")
 
-var tagDefaultRx = regexp.MustCompile(`^(.+),\w*(default=.*)$`)
+var tagDefaultRx = regexp.MustCompile(`^(.+),\s*(default=.*)$`)
 
 func parseTagValue(str string, validOptions []envTagOption) (envTag, error) {
 	var parts []string

--- a/envconfig.go
+++ b/envconfig.go
@@ -7,6 +7,7 @@ package envconfig
 
 import (
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -27,8 +28,17 @@ type envTagOption struct {
 // ErrNotSet is the error that gets wrapped when a "required" env-var is not set.
 var ErrNotSet = errors.New("is not set")
 
+var tagDefaultRx = regexp.MustCompile(`^(.+),\w*(default=.*)$`)
+
 func parseTagValue(str string, validOptions []envTagOption) (envTag, error) {
-	parts := strings.Split(str, ",")
+	var parts []string
+	// Split string on comma, but leave everything after default= intact
+	if m := tagDefaultRx.FindStringSubmatch(str); m != nil {
+		parts = strings.Split(m[1], ",")
+		parts = append(parts, m[2])
+	} else {
+		parts = strings.Split(str, ",")
+	}
 	ret := envTag{
 		Name:    strings.TrimSpace(parts[0]),
 		Options: make(map[string]string, len(parts)-1),

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -229,6 +229,32 @@ func TestSmokeTestAllParsers(t *testing.T) {
 				Expected: `&{3m2s}`,
 			},
 		},
+		"[]string": {
+			"comma-split-trim": {
+				Object: &struct {
+					Value []string `env:"VALUE,parser=comma-split-trim"`
+				}{},
+				EnvVar:   "first, second,third",
+				Expected: `&{[first second third]}`,
+			},
+			"comma-split-trim-default": {
+				// Use NO_VALUE instead of VALUE here to trigger the default. It's not triggered
+				// unless the env is unset.
+				Object: &struct {
+					Value []string `env:"UNSET_VALUE,parser=comma-split-trim,default=first,second, third"`
+				}{},
+				Expected: `&{[first second third]}`,
+			},
+			"comma-split-trim-empty-override-default": {
+				// Explicitly setting an env to an empty string is different from not having it set at all.
+				// For []string, this means overriding the default with an empty list.
+				Object: &struct {
+					Value []string `env:"VALUE,parser=comma-split-trim,default=first,second, third"`
+				}{},
+				EnvVar:   "",
+				Expected: `&{[]}`,
+			},
+		},
 	}
 
 	for typeName, typetests := range tests {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -241,7 +241,7 @@ func TestSmokeTestAllParsers(t *testing.T) {
 				// Use NO_VALUE instead of VALUE here to trigger the default. It's not triggered
 				// unless the env is unset.
 				Object: &struct {
-					Value []string `env:"UNSET_VALUE,parser=comma-split-trim,default=first,second, third"`
+					Value []string `env:"UNSET_VALUE,parser=comma-split-trim, default=first,second, third"`
 				}{},
 				Expected: `&{[first second third]}`,
 			},

--- a/envconfig_types.go
+++ b/envconfig_types.go
@@ -119,5 +119,18 @@ func DefaultFieldTypeHandlers() map[reflect.Type]FieldTypeHandler {
 			},
 			Setter: func(dst reflect.Value, src interface{}) { dst.SetInt(int64(src.(time.Duration))) },
 		},
+		// []string
+		reflect.TypeOf([]string{}): {
+			Parsers: map[string]func(string) (interface{}, error){
+				"comma-split-trim": func(str string) (interface{}, error) {
+					ss := strings.Split(str, ",")
+					for i, s := range ss {
+						ss[i] = strings.TrimSpace(s)
+					}
+					return ss, nil
+				},
+			},
+			Setter: func(dst reflect.Value, src interface{}) { dst.Set(reflect.ValueOf(src)) },
+		},
 	}
 }


### PR DESCRIPTION
Adds a parser that splits on comma and trims each value. For this to work, the `default` must always be the last item in the `env` tag, because the value might contain commas.