### PR TITLE
Fix glitch in comma-split-empty giving one element slice on empty input

### DIFF
--- a/envconfig_types.go
+++ b/envconfig_types.go
@@ -131,6 +131,11 @@ func DefaultFieldTypeHandlers() map[reflect.Type]FieldTypeHandler {
 		reflect.TypeOf([]string{}): {
 			Parsers: map[string]func(string) (interface{}, error){
 				"comma-split-trim": func(str string) (interface{}, error) {
+					// We don't want strings.Split to create a one element slice for an empty string so
+					// a special check is needed for that here.
+					if str == "" {
+						return []string{}, nil
+					}
 					ss := strings.Split(str, ",")
 					for i, s := range ss {
 						ss[i] = strings.TrimSpace(s)


### PR DESCRIPTION
A `strings.Split("", ",")` annoyingly produces a one element slice with an empty string in it. This is somewhat counterintuitive and doesn't align well with other types that produces a zero value for `default=`.

This commit ensures that an empty string instead yields an empty slice.

A consequence of this change is that it's now impossible to get a slice containing one empty string. I think we can live with that.