### PR TITLE
Enable expansion of ${XXX} constructs

### DIFF
--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -68,7 +68,7 @@ func TestAbsoluteURL(t *testing.T) {
 
 func TestExpandedEnv(t *testing.T) {
 	var config struct {
-		Value *url.URL `env:"EXPANDED_VALUE,parser=absolute-URL"`
+		Value string `env:"EXPANDED_VALUE,parser=nonempty-string"`
 	}
 	parser, err := envconfig.GenerateParser(reflect.TypeOf(config), nil)
 	if err != nil {
@@ -82,7 +82,7 @@ func TestExpandedEnv(t *testing.T) {
 	assert.Equal(t, len(warn), 0, "There should be no warnings")
 	assert.Equal(t, len(fatal), 0, "There should be no errors")
 	require.NotNil(t, config.Value)
-	assert.Equal(t, config.Value.String(), "http://example.com/path")
+	assert.Equal(t, config.Value, "http://${VALUE}/path")
 }
 
 func TestExpandedDefault(t *testing.T) {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -3,7 +3,6 @@ package envconfig_test
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -14,6 +13,13 @@ import (
 	"github.com/datawire/envconfig"
 )
 
+type testEnv map[string]string
+
+func (e testEnv) lookup(key string) (string, bool) {
+	v, ok := e[key]
+	return v, ok
+}
+
 // Note: DO NOT use t.Parallel(); because these tests all make use of
 // the global environment (os.Getenv/os.Setenv), they are not safe to
 // run in parallel.
@@ -22,6 +28,7 @@ func TestAbsoluteURL(t *testing.T) {
 	var config struct {
 		U *url.URL `env:"CONFIG_URL,parser=absolute-URL"`
 	}
+	env := testEnv{}
 	parser, err := envconfig.GenerateParser(reflect.TypeOf(config), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -40,9 +47,9 @@ func TestAbsoluteURL(t *testing.T) {
 		tc := tc // capture loop variable
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			config.U = nil
-			t.Setenv("CONFIG_URL", tc.Input)
+			env["CONFIG_URL"] = tc.Input
 
-			warn, fatal := parser.ParseFromEnv(&config, os.LookupEnv)
+			warn, fatal := parser.ParseFromEnv(&config, env.lookup)
 
 			assert.Equal(t, len(warn), 0, "There should be no warnings")
 			if tc.ExpectError {
@@ -71,10 +78,12 @@ func TestRecursive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("PARENT_THING", "foo")
-	t.Setenv("CHILD_THING1", "bar")
-	t.Setenv("CHILD_THING2", "baz")
-	warn, fatal := parser.ParseFromEnv(&config, os.LookupEnv)
+	env := testEnv{
+		"PARENT_THING": "foo",
+		"CHILD_THING1": "bar",
+		"CHILD_THING2": "baz",
+	}
+	warn, fatal := parser.ParseFromEnv(&config, env.lookup)
 	assert.Equal(t, len(warn), 0, "There should be no warnings")
 	assert.Equal(t, len(fatal), 0, "There should be no errors")
 	assert.Equal(t, config.ParentThing, "foo")
@@ -291,16 +300,12 @@ func TestSmokeTestAllParsers(t *testing.T) {
 			for parserName, testinfo := range typetests {
 				testinfo := testinfo
 				t.Run(parserName, func(t *testing.T) {
+					env := testEnv{"VALUE": testinfo.EnvVar}
 					parser, err := envconfig.GenerateParser(reflect.TypeOf(testinfo.Object).Elem(), nil)
 					if err != nil {
 						t.Fatal(err)
 					}
-					warn, fatal := parser.ParseFromEnv(testinfo.Object, func(key string) (string, bool) {
-						if key == "VALUE" {
-							return testinfo.EnvVar, true
-						}
-						return "", false
-					})
+					warn, fatal := parser.ParseFromEnv(testinfo.Object, env.lookup)
 					assert.Equalf(t, testinfo.Warnings, len(warn), "There should be %d warnings", testinfo.Warnings)
 					assert.Equalf(t, testinfo.Errors, len(fatal), "There should be %d errors", testinfo.Errors)
 					format := testinfo.Format


### PR DESCRIPTION
Environment variables containing `${XXX}` can be expanded using the
standard `os.Expand(key string, func(string) string) string` function,
but at present, the `envconfig` will not fully facilitate this. If
an expansion is added to a `default=`, then the unexpanded value will
be passed to the associated parser during validation. Consequently, a
declaration like this one:
```golang
AuthURL *url.URL `env:"AUTH_URL, parser=absolute-URL, default=https://${DOMAIN}/auth"`
```
will always fail since '${}' isn't allowed in a URL address.

This commit fixes this by:
1. Disabling validation of default values that contain expansions during
   parser generation. Such values cannot be validated until used.
2. Ensuring that the ${XXX} notation can be used in defaults by
   expanding such values before passing them to the parser.