### PR TITLE
Ignore fields unless they have an env-tag or is a struct

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -143,6 +143,11 @@ func GenerateParser(structInfo reflect.Type, typeHandlers map[reflect.Type]Field
 		i := i // capture loop variable
 		var fieldInfo reflect.StructField = structInfo.Field(i)
 
+		if fieldInfo.Tag.Get("env") == "" && fieldInfo.Type.Kind() != reflect.Struct {
+			// A field is ignored unless it has an "env" tag or is a struct
+			continue
+		}
+
 		typeHandler, typeHandlerOK := typeHandlers[fieldInfo.Type]
 		if !typeHandlerOK {
 			if fieldInfo.Type.Kind() != reflect.Struct {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -66,6 +66,22 @@ func TestAbsoluteURL(t *testing.T) {
 	}
 }
 
+func TestIgnoredField(t *testing.T) {
+	var config struct {
+		Value   string `env:"VALUE,parser=nonempty-string"`
+		ignored func(string) (string, bool)
+	}
+	parser, err := envconfig.GenerateParser(reflect.TypeOf(config), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := testEnv{"VALUE": "value"}
+	warn, fatal := parser.ParseFromEnv(&config, env.lookup)
+	assert.Equal(t, len(warn), 0, "There should be no warnings")
+	assert.Equal(t, len(fatal), 0, "There should be no errors")
+	assert.Equal(t, config.Value, "value")
+}
+
 func TestExpandedEnv(t *testing.T) {
 	var config struct {
 		Value string `env:"EXPANDED_VALUE,parser=nonempty-string"`


### PR DESCRIPTION
It is sometimes desirable to have fields that don't map 1:1 with environment variables in the same struct as fields that do. This commit ensures that fields that have no `env` tag and are not structs (which may contain nested env tags), are ignored.